### PR TITLE
fix: fetch bundled ffmpeg for source checkouts

### DIFF
--- a/scripts/run.cjs
+++ b/scripts/run.cjs
@@ -86,6 +86,38 @@ const STEPS = {
   'dist:all': [['electron-vite', 'build'], ['electron-builder', '--mac', '--win']]
 }
 
+function ffmpegBin() {
+  return IS_WIN
+    ? path.join(ROOT, 'extras', 'ffmpeg-win', 'ffmpeg.exe')
+    : path.join(ROOT, 'extras', 'ffmpeg-mac', 'ffmpeg')
+}
+
+/* the app shells out to a bundled ffmpeg. CI fetches it before packaging, so
+   released builds are fine, but a source checkout never gets one — dev starts
+   happily and then fails at split time with "Something went wrong with the
+   built-in audio tools". Fetch it on demand with the same scripts CI runs. */
+function ensureFfmpeg() {
+  if (fs.existsSync(ffmpegBin())) return
+  const manual = IS_WIN
+    ? 'powershell -ExecutionPolicy Bypass -File scripts/fetch-ffmpeg.ps1'
+    : 'bash scripts/fetch-ffmpeg.sh'
+  console.log('> fetching bundled ffmpeg (one time)')
+  const r = IS_WIN
+    ? spawnSync(
+        'powershell',
+        ['-ExecutionPolicy', 'Bypass', '-File', path.join('scripts', 'fetch-ffmpeg.ps1')],
+        { cwd: ROOT, stdio: 'inherit' }
+      )
+    : spawnSync('bash', [path.join('scripts', 'fetch-ffmpeg.sh')], {
+        cwd: ROOT,
+        stdio: 'inherit'
+      })
+  if (r.status !== 0 || !fs.existsSync(ffmpegBin())) {
+    console.error(`Could not fetch ffmpeg. Fetch it manually, then re-run:\n  ${manual}`)
+    process.exit(r.status || 1)
+  }
+}
+
 function resolveBin(name) {
   const ext = IS_WIN ? '.cmd' : ''
   const local = path.join(ROOT, 'node_modules', '.bin', name + ext)
@@ -113,6 +145,10 @@ function runSteps(steps) {
   }
 }
 
+// commands that produce or run the app need the bundled ffmpeg present;
+// typecheck and plain build do not
+const NEEDS_FFMPEG = new Set(['dev', 'dist', 'dist:win', 'dist:all'])
+
 function main() {
   const cmd = process.argv[2]
   const steps = STEPS[cmd]
@@ -138,6 +174,8 @@ function main() {
     })
     process.exit(r.status ?? 1)
   }
+
+  if (NEEDS_FFMPEG.has(cmd)) ensureFfmpeg()
 
   runSteps(steps)
 }


### PR DESCRIPTION
The app shells out to a bundled ffmpeg resolved from extras/. CI fetches it before packaging (release.yml, windows-smoke.yml), so released builds are fine, but nothing fetches it for a source checkout: extras/ is gitignored and `npm run dev` never invokes scripts/fetch-ffmpeg.*.

On a machine with no system ffmpeg on the probe list, dev therefore starts cleanly, completes engine setup, and only fails once the user actually splits a song, with a message that points at the wrong thing:

  Something went wrong with the built-in audio tools.
  Try reinstalling StemKit.

Reinstalling does not help, because the app is running from source.

run.cjs now checks for the host platform's ffmpeg before the commands that run or package the app, and shells out to the same fetch scripts CI uses when it is missing. typecheck and plain build are untouched, since neither needs it. When the fetch fails the runner stops with the manual command rather than launching an app that cannot split.

Cross-target packaging (dist:all, or dist:win from macOS) still only fetches the host platform's binary, as before — no regression, but not addressed here either.

Verified on macOS: fetches when missing, silent no-op when present, not invoked for typecheck, and exits non-zero with instructions both when the fetch script fails and when it reports success without producing a binary.