### PR TITLE
feat: add karaoke lyrics overlay from lrclib.net

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,6 +13,7 @@ import {
 } from './env'
 import { loadSongs, removeSong, stemBuffers, stemsDir, stemsFor, mixWavPath } from './library'
 import { startJob, cancelJob, searchYouTube } from './pipeline'
+import { fetchLyrics } from './lyrics'
 import { initUpdater } from './updater'
 import { runSmoke } from './smoke'
 
@@ -184,6 +185,9 @@ app.whenReady().then(async () => {
   })
 
   ipcMain.handle('search:youtube', (_e, query: string) => searchYouTube(query))
+  ipcMain.handle('lyrics:fetch', (_e, videoId: string, title: string, duration: number) =>
+    fetchLyrics(String(videoId ?? ''), String(title ?? ''), Number(duration) || 0)
+  )
   ipcMain.handle('app:version', () => app.getVersion())
   initUpdater()
   ipcMain.handle('open-external', (_e, url: string) => {

--- a/src/main/lyrics.ts
+++ b/src/main/lyrics.ts
@@ -1,0 +1,82 @@
+import { app, net } from 'electron'
+import type { LyricsResult } from '../shared/types'
+
+/* lyrics lookup via lrclib.net (free, no API key). Runs in the main process
+   because the renderer CSP restricts connect-src to 'self'. Results are
+   cached per video for the session; a miss is cached too so we never hammer
+   the API for songs that have no lyrics */
+
+interface LrcLibItem {
+  trackName?: string
+  artistName?: string
+  duration?: number
+  instrumental?: boolean
+  syncedLyrics?: string | null
+  plainLyrics?: string | null
+}
+
+const cache = new Map<string, LyricsResult>()
+
+const NONE: LyricsResult = { found: false, synced: null, plain: null }
+
+/* YouTube titles carry noise like "(Official Video)" or "[4K Remaster]" that
+   ruins the search; strip bracketed segments containing such words */
+function cleanTitle(raw: string): string {
+  return raw
+    .replace(/[([{][^)\]}]*[)\]}]/g, (m) =>
+      /official|video|audio|lyric|visuali[sz]er|remaster|live|explicit|clean|hd|4k|mv|m\/v/i.test(m)
+        ? ' '
+        : m
+    )
+    .replace(/\b(official\s+(music\s+)?video|official\s+audio|lyrics?\s+video|full\s+video)\b/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+async function search(title: string, duration: number): Promise<LyricsResult> {
+  const q = cleanTitle(title)
+  if (!q) return NONE
+  const res = await net.fetch(`https://lrclib.net/api/search?q=${encodeURIComponent(q)}`, {
+    headers: {
+      'User-Agent': `StemKit/${app.getVersion()} (https://github.com/danielravina/stemkit)`
+    },
+    signal: AbortSignal.timeout(15000)
+  })
+  if (!res.ok) return NONE
+  const items = (await res.json()) as LrcLibItem[]
+  const usable = (Array.isArray(items) ? items : []).filter(
+    (i) => !i.instrumental && ((i.syncedLyrics ?? '').trim() || (i.plainLyrics ?? '').trim())
+  )
+  if (usable.length === 0) return NONE
+
+  // prefer synced lyrics, then the closest runtime to our track
+  const score = (i: LrcLibItem): number => {
+    let s = (i.syncedLyrics ?? '').trim() ? 10 : 0
+    if (duration > 0 && typeof i.duration === 'number') {
+      const diff = Math.abs(i.duration - duration)
+      if (diff <= 3) s += 6
+      else if (diff <= 10) s += 3
+      else if (diff > 30) s -= 6
+    }
+    return s
+  }
+  usable.sort((a, b) => score(b) - score(a))
+  const best = usable[0]
+  return {
+    found: true,
+    synced: (best.syncedLyrics ?? '').trim() || null,
+    plain: (best.plainLyrics ?? '').trim() || null
+  }
+}
+
+export async function fetchLyrics(
+  videoId: string,
+  title: string,
+  duration: number
+): Promise<LyricsResult> {
+  const hit = cache.get(videoId)
+  if (hit) return hit
+  const result = await search(title, duration).catch(() => NONE)
+  cache.set(videoId, result)
+  return result
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -19,6 +19,8 @@ const api: StemKitApi = {
   exportStem: (videoId, stem) => ipcRenderer.invoke('stem:export', videoId, stem),
   exportAllStems: (videoId) => ipcRenderer.invoke('stems:export-all', videoId),
   searchYouTube: (query) => ipcRenderer.invoke('search:youtube', query),
+  fetchLyrics: (videoId, title, duration) =>
+    ipcRenderer.invoke('lyrics:fetch', videoId, title, duration),
   startJob: (url, model, stems) => ipcRenderer.invoke('jobs:start', url, model, stems),
   cancelJob: (videoId?: string) => ipcRenderer.invoke('jobs:cancel', videoId),
   openExternal: (url) => ipcRenderer.invoke('open-external', url),

--- a/src/renderer/src/components/Icons.tsx
+++ b/src/renderer/src/components/Icons.tsx
@@ -117,6 +117,16 @@ export function ExternalIcon({ className = base }: IconProps) {
   )
 }
 
+export function LyricsIcon({ className = base }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <path d="M9 19V6l10-2v13" />
+      <circle cx="7" cy="19" r="2.2" />
+      <circle cx="17" cy="17" r="2.2" />
+    </svg>
+  )
+}
+
 export function LogoMark({ className = 'w-7 h-7' }: IconProps) {
   return (
     <svg viewBox="0 0 32 32" fill="none" className={className}>

--- a/src/renderer/src/components/LyricsPanel.tsx
+++ b/src/renderer/src/components/LyricsPanel.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+
+interface Line {
+  t: number
+  text: string
+}
+
+function parseLrc(raw: string): Line[] {
+  const lines: Line[] = []
+  for (const row of raw.split(/\r?\n/)) {
+    const tags = [...row.matchAll(/\[(\d{1,2}):(\d{2})(?:\.(\d{1,3}))?\]/g)]
+    if (tags.length === 0) continue
+    const text = row.replace(/\[[^\]]*\]/g, '').trim()
+    if (!text) continue
+    for (const m of tags) {
+      const frac = m[3] ? Number(m[3].padEnd(3, '0').slice(0, 3)) / 1000 : 0
+      lines.push({ t: Number(m[1]) * 60 + Number(m[2]) + frac, text })
+    }
+  }
+  lines.sort((a, b) => a.t - b.t)
+  return lines
+}
+
+function activeIndex(lines: Line[], pos: number): number {
+  let lo = 0
+  let hi = lines.length - 1
+  let hit = -1
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1
+    if (lines[mid].t <= pos) {
+      hit = mid
+      lo = mid + 1
+    } else {
+      hi = mid - 1
+    }
+  }
+  return hit
+}
+
+interface Props {
+  videoId: string
+  title: string
+  duration: number
+  getPosition: () => number
+}
+
+export function LyricsPanel({
+  videoId,
+  title,
+  duration,
+  getPosition
+}: Props): React.ReactElement {
+  const [status, setStatus] = useState<'loading' | 'ready' | 'missing'>('loading')
+  const [syncedRaw, setSyncedRaw] = useState<string | null>(null)
+  const [plain, setPlain] = useState<string | null>(null)
+  const [current, setCurrent] = useState(-1)
+  const scrollerRef = useRef<HTMLDivElement>(null)
+  const activeRef = useRef<HTMLDivElement>(null)
+  const scrollRaf = useRef(0)
+  const getPositionRef = useRef(getPosition)
+  getPositionRef.current = getPosition
+
+  useEffect(() => {
+    let cancelled = false
+    setStatus('loading')
+    setSyncedRaw(null)
+    setPlain(null)
+    setCurrent(-1)
+    void window.stemkit
+      .fetchLyrics(videoId, title, duration)
+      .then((res) => {
+        if (cancelled) return
+        if (res.found && (res.synced || res.plain)) {
+          setSyncedRaw(res.synced)
+          setPlain(res.plain)
+          setStatus('ready')
+        } else {
+          setStatus('missing')
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setStatus('missing')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [videoId, title, duration])
+
+  const lines = useMemo(() => (syncedRaw ? parseLrc(syncedRaw) : []), [syncedRaw])
+  const linesRef = useRef(lines)
+  linesRef.current = lines
+
+  useEffect(() => {
+    if (status !== 'ready' || lines.length === 0) return
+    let raf = 0
+    const tick = (): void => {
+      const idx = activeIndex(linesRef.current, getPositionRef.current())
+      setCurrent((prev) => (prev === idx ? prev : idx))
+    }
+    tick()
+    const loop = (): void => {
+      tick()
+      raf = requestAnimationFrame(loop)
+    }
+    raf = requestAnimationFrame(loop)
+    return () => cancelAnimationFrame(raf)
+  }, [status, lines.length])
+
+  useLayoutEffect(() => {
+    const root = scrollerRef.current
+    const el = activeRef.current
+    if (!root || !el || current < 0) return
+
+    cancelAnimationFrame(scrollRaf.current)
+    const from = root.scrollTop
+    const rootRect = root.getBoundingClientRect()
+    const elRect = el.getBoundingClientRect()
+    const delta = elRect.top + elRect.height / 2 - (rootRect.top + rootRect.height / 2)
+    if (Math.abs(delta) < 1) return
+    const to = from + delta
+    const started = performance.now()
+    const durationMs = 420
+    const ease = (t: number): number => 1 - (1 - t) ** 3
+
+    const step = (now: number): void => {
+      const t = Math.min(1, (now - started) / durationMs)
+      root.scrollTop = from + (to - from) * ease(t)
+      if (t < 1) scrollRaf.current = requestAnimationFrame(step)
+    }
+    scrollRaf.current = requestAnimationFrame(step)
+    return () => cancelAnimationFrame(scrollRaf.current)
+  }, [current])
+
+  return (
+    <div
+      ref={scrollerRef}
+      className="mt-4 lyrics-panel rounded-2xl min-h-[280px] max-h-[52vh] overflow-y-auto overflow-x-hidden px-8 py-10"
+    >
+      {status === 'loading' && (
+        <p className="text-center text-sm text-white/40 tracking-wide">Looking up lyrics…</p>
+      )}
+      {status === 'missing' && (
+        <p className="text-center text-sm text-white/45">Lyrics not available</p>
+      )}
+      {status === 'ready' && lines.length > 0 && (
+        <div className="lyric-list">
+          {lines.map((line, i) => {
+            const dist = current < 0 ? 1 : i - current
+            const kind = dist === 0 ? 'is-active' : dist < 0 ? 'is-past' : 'is-next'
+            return (
+              <div
+                key={`${line.t}-${i}`}
+                ref={dist === 0 ? activeRef : undefined}
+                className={`lyric-line ${kind}`}
+              >
+                {line.text}
+              </div>
+            )
+          })}
+        </div>
+      )}
+      {status === 'ready' && lines.length === 0 && plain && (
+        <pre className="whitespace-pre-wrap text-center text-[16px] leading-relaxed text-white/70 font-sans">
+          {plain}
+        </pre>
+      )}
+      {status === 'ready' && lines.length === 0 && !plain && (
+        <p className="text-center text-sm text-white/45">Lyrics not available</p>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/Player.tsx
+++ b/src/renderer/src/components/Player.tsx
@@ -5,6 +5,7 @@ import { buildStemMeta } from '../lib/stems'
 import { fmtTime } from '../lib/format'
 import { YouTubeHost, type YTState } from '../lib/youtube'
 import { StemLane } from './StemLane'
+import { LyricsPanel } from './LyricsPanel'
 import { Transport, type PresetId } from './Transport'
 import { DownloadIcon } from './Icons'
 
@@ -54,6 +55,7 @@ export function Player({ song }: Props): React.ReactElement {
   const [solos, setSolos] = useState<Set<StemId>>(new Set())
   const [master, setMaster] = useState(0.9)
   const [preset, setPreset] = useState<PresetId | 'custom'>('all')
+  const [showLyrics, setShowLyrics] = useState(false)
 
   const stemMeta = useMemo(() => buildStemMeta(Object.keys(buffers) as StemId[]), [buffers])
 
@@ -77,6 +79,7 @@ export function Player({ song }: Props): React.ReactElement {
     setMutes(new Set())
     setSolos(new Set())
     setPreset('all')
+    setShowLyrics(false)
     engine.stopAll()
 
     let cancelled = false
@@ -243,9 +246,10 @@ export function Player({ song }: Props): React.ReactElement {
     setPreset(p)
     setMutes(new Set())
     if (p === 'all') setSolos(new Set())
-    else if (p === 'karaoke')
+    else if (p === 'karaoke') {
       setSolos(new Set<StemId>(stemMeta.filter((s) => s.id !== 'vocals').map((s) => s.id)))
-    else if (p === 'acapella') setSolos(new Set<StemId>(['vocals']))
+      setShowLyrics(true)
+    } else if (p === 'acapella') setSolos(new Set<StemId>(['vocals']))
     else if (p === 'drumnbass') setSolos(new Set<StemId>(['drums', 'bass']))
   }
 
@@ -372,9 +376,20 @@ export function Player({ song }: Props): React.ReactElement {
             master={master}
             onMaster={setMaster}
             youtubeUrl={youtubeUrl}
+            lyricsOpen={showLyrics}
+            onToggleLyrics={() => setShowLyrics((v) => !v)}
           />
 
-          <div className="mt-4 space-y-2">
+          {showLyrics && (
+            <LyricsPanel
+              videoId={song.videoId}
+              title={song.title}
+              duration={song.duration}
+              getPosition={getPosition}
+            />
+          )}
+
+          <div className={`mt-4 space-y-2 ${preset === 'karaoke' && showLyrics ? 'hidden' : ''}`}>
             {stemMeta.map((meta) => (
               <StemLane
                 key={meta.id}

--- a/src/renderer/src/components/Transport.tsx
+++ b/src/renderer/src/components/Transport.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { fmtTime } from '../lib/format'
-import { PlayIcon, PauseIcon, ExternalIcon } from './Icons'
+import { PlayIcon, PauseIcon, ExternalIcon, LyricsIcon } from './Icons'
 
 export type PresetId = 'all' | 'karaoke' | 'acapella' | 'drumnbass'
 
@@ -22,6 +22,8 @@ interface Props {
   master: number
   onMaster: (v: number) => void
   youtubeUrl: string
+  lyricsOpen: boolean
+  onToggleLyrics: () => void
 }
 
 function SeekBar({
@@ -102,7 +104,9 @@ export function Transport({
   onPreset,
   master,
   onMaster,
-  youtubeUrl
+  youtubeUrl,
+  lyricsOpen,
+  onToggleLyrics
 }: Props): React.ReactElement {
   return (
     <div className="glass rounded-2xl px-5 py-4 mt-4 flex flex-col gap-4">
@@ -121,20 +125,34 @@ export function Transport({
           )}
         </button>
 
-        <div className="no-drag flex items-center gap-1 bg-white/5 rounded-full p-1">
-          {PRESETS.map((p) => (
-            <button
-              key={p.id}
-              onClick={() => onPreset(p.id)}
-              className={`px-3.5 py-1.5 rounded-full text-[13px] font-medium transition-all ${
-                preset === p.id
-                  ? 'bg-white/90 text-black'
-                  : 'text-white/60 hover:text-white'
-              }`}
-            >
-              {p.label}
-            </button>
-          ))}
+        <div className="no-drag flex items-center gap-2">
+          <div className="flex items-center gap-1 bg-white/5 rounded-full p-1">
+            {PRESETS.map((p) => (
+              <button
+                key={p.id}
+                onClick={() => onPreset(p.id)}
+                className={`px-3.5 py-1.5 rounded-full text-[13px] font-medium transition-all ${
+                  preset === p.id
+                    ? 'bg-white/90 text-black'
+                    : 'text-white/60 hover:text-white'
+                }`}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={onToggleLyrics}
+            title={lyricsOpen ? 'Hide lyrics' : 'Show lyrics'}
+            className={`px-3 py-1.5 rounded-full text-[13px] font-medium transition-all flex items-center gap-1.5 ${
+              lyricsOpen
+                ? 'bg-violet-400/90 text-black'
+                : 'bg-white/5 text-white/60 hover:text-white'
+            }`}
+          >
+            <LyricsIcon className="w-3.5 h-3.5" />
+            Lyrics
+          </button>
         </div>
 
         <div className="flex items-center gap-3 w-44">

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -94,3 +94,46 @@ input[type="range"]:hover::-webkit-slider-thumb {
   border: 1px solid rgba(255, 255, 255, 0.08);
   backdrop-filter: blur(18px);
 }
+
+.lyrics-panel {
+  position: relative;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  scroll-behavior: auto;
+}
+
+.lyric-list {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 0;
+  text-align: center;
+}
+
+.lyric-line {
+  max-width: 42rem;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 1.35;
+  color: rgba(255, 255, 255, 0.55);
+  opacity: 0.9;
+  transform: scale(1);
+  transform-origin: center center;
+  transition: transform 0.25s ease, opacity 0.25s ease, color 0.25s ease;
+  contain: layout paint;
+}
+
+.lyric-line.is-past {
+  color: rgba(255, 255, 255, 0.32);
+  opacity: 0.75;
+  transform: scale(0.97);
+}
+
+.lyric-line.is-active {
+  font-weight: 600;
+  color: #fff;
+  opacity: 1;
+  transform: scale(1.04);
+  text-shadow: 0 0 14px rgba(167, 139, 250, 0.2);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -68,6 +68,12 @@ export interface UpdateEvent {
   pct?: number
 }
 
+export interface LyricsResult {
+  found: boolean
+  synced: string | null
+  plain: string | null
+}
+
 export interface StemKitApi {
   envStatus(): Promise<EnvStatus>
   envBootstrap(): Promise<boolean>
@@ -78,6 +84,7 @@ export interface StemKitApi {
   exportStem(videoId: string, stem: string): Promise<{ saved: boolean; path?: string }>
   exportAllStems(videoId: string): Promise<{ saved: boolean; path?: string; count?: number }>
   searchYouTube(query: string): Promise<SearchResult[]>
+  fetchLyrics(videoId: string, title: string, duration: number): Promise<LyricsResult>
   startJob(url: string, model?: string, stems?: string[]): Promise<{ started: boolean }>
   cancelJob(videoId?: string): Promise<void>
   openExternal(url: string): Promise<void>


### PR DESCRIPTION
## Summary

Adds synchronized lyrics support across all mix modes.

### What's Changed

* Added a toggleable **Lyrics panel** for:

  * All
  * Karaoke
  * Acapella
  * Drums + Bass
* Karaoke mode continues to mute vocals and now opens the Lyrics panel by default.
* Fetches timed lyrics from [[LRCLIB](https://lrclib.net/)](https://lrclib.net/).
* Highlights the current lyric line based on playback position.
* Automatically scrolls to keep the active lyric visible.
* Displays `Lyrics not available` when no lyrics are found.
* Hiding the Lyrics panel restores the regular stem lanes.

Fixes #5

## Test Plan

* [x] Split a well-known song and enable Lyrics.
* [x] Confirm the highlighted lyric follows audio playback.
* [x] Confirm the lyrics automatically scroll during playback.
* [x] Test a song with no available lyrics and confirm `Lyrics not available` is displayed.
* [x] Confirm All, Acapella, and Drums + Bass still display stem lanes correctly with Lyrics enabled and disabled.
* [x] Hide Lyrics in Karaoke mode and confirm the stem lanes return.