### PR TITLE
fix: bundle Windows ffmpeg with libsoxr

### DIFF
--- a/scripts/fetch-ffmpeg.ps1
+++ b/scripts/fetch-ffmpeg.ps1
@@ -6,16 +6,22 @@ New-Item -ItemType Directory -Force -Path $out | Out-Null
 
 $existing = Join-Path $out "ffmpeg.exe"
 if (Test-Path $existing) {
-    Write-Host "ffmpeg already present: $existing"
-    & $existing -version | Select-Object -First 1
-    exit 0
+    $buildconf = (& $existing -hide_banner -buildconf 2>&1 | Out-String)
+    if ($LASTEXITCODE -eq 0 -and $buildconf -match '--enable-libsoxr') {
+        Write-Host "ffmpeg with libsoxr already present: $existing"
+        & $existing -version | Select-Object -First 1
+        exit 0
+    }
+
+    Write-Host "existing ffmpeg lacks libsoxr support; replacing it..."
+    Remove-Item -Force $existing
 }
 
-$zip = Join-Path $env:TEMP "ffmpeg-essentials.zip"
+$zip = Join-Path $env:TEMP "ffmpeg-btbn.zip"
 $tmpExtract = Join-Path $env:TEMP "ffmpeg-extract"
 
-Write-Host "downloading static ffmpeg for Windows x64..."
-Invoke-WebRequest -Uri "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip" -OutFile $zip
+Write-Host "downloading static ffmpeg with libsoxr for Windows x64..."
+Invoke-WebRequest -Uri "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n9.0-latest-win64-gpl-9.0.zip" -OutFile $zip
 
 if (Test-Path $tmpExtract) { Remove-Item -Recurse -Force $tmpExtract }
 Expand-Archive -Path $zip -DestinationPath $tmpExtract -Force
@@ -26,6 +32,12 @@ if (-not $exe) { throw "ffmpeg.exe not found inside archive" }
 Copy-Item $exe.FullName $existing -Force
 Remove-Item -Recurse -Force $tmpExtract
 Remove-Item -Force $zip
+
+$buildconf = (& $existing -hide_banner -buildconf 2>&1 | Out-String)
+if ($LASTEXITCODE -ne 0 -or $buildconf -notmatch '--enable-libsoxr') {
+    Remove-Item -Force $existing
+    throw "downloaded ffmpeg does not include libsoxr support"
+}
 
 & $existing -version | Select-Object -First 1
 Write-Host "saved to $existing"


### PR DESCRIPTION
## Summary

This fixes Windows splitting without changing the audio conversion path introduced in the quality improvements.

StemKit converts downloaded audio with `aresample=44100:resampler=soxr`, but the Windows fetch script bundled Gyan's FFmpeg Essentials build, which does not include `libsoxr`.  On Windows, this caused FFmpeg to fail before separation began.

## Fix

- Switch the Windows FFmpeg fetch script to [BtbN](https://github.com/BtbN/FFmpeg-Builds)'s static Windows x64 GPL build, which includes `libsoxr`.
- Keep the existing SoXR resampling command unchanged.
- Continue bundling a single `ffmpeg.exe`, with no additional runtime dependency or user setup.
- Verify `--enable-libsoxr` in `ffmpeg -buildconf` before accepting an existing or newly downloaded binary.
- Replace a previously cached FFmpeg binary when it lacks SoXR support.

## Why This Approach

Removing `resampler=soxr` also avoids the failure, but is a regression from the behavior introduced by the quality improvements.  This fixes the packaging mismatch instead.

BtbN publishes the required x64 static builds as a ZIP, so the existing PowerShell `Expand-Archive` flow remains intact and StemKit stays plug-and-play.

## Testing

Tested locally on Windows:

- Reproduced the original FFmpeg failure on release [`0.1.18`](https://github.com/danvelope/stemkit/releases/tag/untagged-32dfd61bd8f619d92b0a) .
- Reproduced the original FFmpeg failure on commit https://github.com/danvelope/stemkit/commit/3865f1e855e25ceb21c60b559c78a92db0ad3981.
- Confirmed the replacement binary reports `--enable-libsoxr`.
- Ran StemKit with the original `aresample=44100:resampler=soxr` conversion intact.
- Confirmed splitting proceeds past conversion and into separation successfully.