### PR TITLE
feat: linux support (dev, cuda, AppImage+deb x64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
             platform: mac
           - os: windows-latest
             platform: win
+          - os: ubuntu-22.04
+            platform: linux
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -38,8 +40,8 @@ jobs:
         if: steps.install.outcome == 'failure'
         run: npm install
 
-      - name: Fetch ffmpeg (mac)
-        if: matrix.platform == 'mac'
+      - name: Fetch ffmpeg (mac/linux)
+        if: matrix.platform == 'mac' || matrix.platform == 'linux'
         run: bash scripts/fetch-ffmpeg.sh
 
       - name: Fetch ffmpeg (win)
@@ -94,4 +96,6 @@ jobs:
             release/*.dmg
             release/*.exe
             release/*.zip
+            release/*.AppImage
+            release/*.deb
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Search YouTube or paste a link, pick the instruments you want, and play the resu
 
 Everything runs locally — no accounts, no cloud, no API keys.
 
-![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-black) ![local](https://img.shields.io/badge/100%25-local-emerald)
+![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-black) ![local](https://img.shields.io/badge/100%25-local-emerald)
 
 <p align="center">
   <img src="docs/stemkit.png" alt="StemKit splitting Queen's Bohemian Rhapsody into six stems — video player, presets and color-coded waveform lanes" width="100%" />
@@ -28,6 +28,7 @@ Everything runs locally — no accounts, no cloud, no API keys.
 Grab installers from [Releases](https://github.com/danvelope/stemkit/releases):
 - **macOS** (Apple Silicon): `StemKit-x.y.z-mac-arm64.dmg`
 - **Windows**: `StemKit-Setup-x.y.z.exe` (installer) or portable `.zip`
+- **Linux** (x64): `StemKit-x.y.z-linux-x86_64.AppImage` (portable, self-updating) or `StemKit-x.y.z-linux-amd64.deb`
 
 First launch creates a private Python environment and downloads the separation engine (~2 GB) — one time. ffmpeg is bundled — nothing else to install.
 
@@ -42,7 +43,7 @@ Optional quality upgrades live behind a gear icon in the app (Settings), each wi
 
 ## Requirements
 
-- **macOS 12+** (Apple Silicon) or **Windows 10/11** (x64)
+- **macOS 12+** (Apple Silicon) or **Windows 10/11** (x64) or **Linux x64** (Ubuntu 22.04+ or equivalent; NVIDIA driver for GPU splits)
 - No manual installs: if no Python 3.9+ is detected, StemKit downloads a private runtime (python-build-standalone) during first-launch setup
 - Node.js 20+ only for building from source
 
@@ -58,13 +59,16 @@ Wrong Node version? Scripts auto-relaunch with a suitable one (nvm / nvm-windows
 ## Build & release
 
 ```bash
-bash scripts/fetch-ffmpeg.sh        # mac (one time)
+bash scripts/fetch-ffmpeg.sh        # mac/linux (one time)
 powershell scripts/fetch-ffmpeg.ps1 # windows (one time)
 
 npm run dist        # mac dmg -> release/
 npm run dist:win    # windows nsis+zip -> release/
+npm run dist:linux  # linux AppImage+deb (x64) -> release/
 npm run dist:all    # both (on the matching OS)
 ```
+
+> **Linux**: building the `.deb` needs `dpkg` + `fakeroot` on the host; running the `.AppImage` needs FUSE. In-app self-update works on the AppImage — `.deb` installs update by re-downloading.
 
 Releases are built by GitHub Actions:
 - push a tag `v*` → binaries attach to a draft GitHub Release

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -37,3 +37,35 @@ win:
 nsis:
   oneClick: true
   perMachine: false
+linux:
+  icon: build/icon.png
+  category: AudioVideo
+  executableName: stemkit
+  vendor: danvelope
+  maintainer: danvelope
+  synopsis: Local YouTube stem splitter and player
+  description: Split songs into isolated stems locally — vocals, drums, bass and more.
+  target:
+    - target: AppImage
+      arch:
+        - x64
+    - target: deb
+      arch:
+        - x64
+  desktop:
+    StartupWMClass: stemkit
+  extraResources:
+    - from: extras/ffmpeg-linux/ffmpeg
+      to: ffmpeg/ffmpeg
+deb:
+  depends:
+    - libgtk-3-0
+    - libnotify4
+    - libnss3
+    - libxss1
+    - libxtst6
+    - xdg-utils
+    - libatspi2.0-0
+    - libuuid1
+    - libsecret-1-0
+    - libasound2

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "typecheck": "node scripts/run.cjs typecheck",
     "dist": "node scripts/run.cjs dist",
     "dist:win": "node scripts/run.cjs dist:win",
+    "dist:linux": "node scripts/run.cjs dist:linux",
     "dist:all": "node scripts/run.cjs dist:all"
   },
   "dependencies": {

--- a/python/separate.py
+++ b/python/separate.py
@@ -115,7 +115,12 @@ def main():
     dapply.tqdm = types.SimpleNamespace(tqdm=ProgressTqdm) if is_module else ProgressTqdm
 
     if args.device == "auto":
-        device = "mps" if torch.backends.mps.is_available() else "cpu"
+        if torch.cuda.is_available():
+            device = "cuda"
+        elif torch.backends.mps.is_available():
+            device = "mps"
+        else:
+            device = "cpu"
     else:
         device = args.device
     if device == "cuda" and not torch.cuda.is_available():

--- a/scripts/fetch-ffmpeg.sh
+++ b/scripts/fetch-ffmpeg.sh
@@ -20,6 +20,40 @@ if [[ "$OS" == "Darwin" ]]; then
   chmod +x "$OUT/ffmpeg"
   "$OUT/ffmpeg" -version | head -1
   echo "saved to $OUT/ffmpeg"
+elif [[ "$OS" == "Linux" ]]; then
+  OUT="$ROOT/extras/ffmpeg-linux"
+  if [[ -x "$OUT/ffmpeg" ]]; then
+    echo "ffmpeg already present: $OUT/ffmpeg"
+    "$OUT/ffmpeg" -version | head -1
+    exit 0
+  fi
+  ARCH="$(uname -m)"
+  case "$ARCH" in
+    x86_64) JV_ARCH="amd64" ;;
+    aarch64|arm64) JV_ARCH="arm64" ;;
+    *)
+      echo "unsupported Linux arch: $ARCH (need x86_64 or aarch64)"
+      exit 1
+      ;;
+  esac
+  mkdir -p "$OUT"
+  echo "downloading static ffmpeg for Linux ($JV_ARCH)..."
+  TMP_TXZ="$ROOT/extras/ffmpeg-linux.tar.xz"
+  TMP_DIR="$ROOT/extras/ffmpeg-linux-extract"
+  curl -fsSL -o "$TMP_TXZ" "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-${JV_ARCH}-static.tar.xz"
+  rm -rf "$TMP_DIR"
+  mkdir -p "$TMP_DIR"
+  tar -xJf "$TMP_TXZ" -C "$TMP_DIR"
+  BIN="$(find "$TMP_DIR" -name ffmpeg -type f | head -1)"
+  if [[ -z "$BIN" ]]; then
+    echo "ffmpeg binary not found inside archive"
+    exit 1
+  fi
+  cp -f "$BIN" "$OUT/ffmpeg"
+  rm -rf "$TMP_DIR" "$TMP_TXZ"
+  chmod +x "$OUT/ffmpeg"
+  "$OUT/ffmpeg" -version | head -1
+  echo "saved to $OUT/ffmpeg"
 elif [[ "$OS" == "MINGW"* || "$OS" == "MSYS"* || "$OS" == "CYGWIN"* ]]; then
   echo "on Windows, run instead: powershell -ExecutionPolicy Bypass -File scripts/fetch-ffmpeg.ps1"
   exit 1

--- a/scripts/run.cjs
+++ b/scripts/run.cjs
@@ -48,7 +48,7 @@ function findNode(requiredMajor) {
       }
     } catch {}
   } else {
-    candidates.push('/opt/homebrew/bin/node', '/usr/local/bin/node')
+    candidates.push('/opt/homebrew/bin/node', '/usr/local/bin/node', '/usr/bin/node')
     const nvmRoot = path.join(os.homedir(), '.nvm', 'versions', 'node')
     try {
       for (const ver of fs.readdirSync(nvmRoot)) {
@@ -87,9 +87,10 @@ const STEPS = {
 }
 
 function ffmpegBin() {
-  return IS_WIN
-    ? path.join(ROOT, 'extras', 'ffmpeg-win', 'ffmpeg.exe')
-    : path.join(ROOT, 'extras', 'ffmpeg-mac', 'ffmpeg')
+  if (IS_WIN) return path.join(ROOT, 'extras', 'ffmpeg-win', 'ffmpeg.exe')
+  if (process.platform === 'darwin')
+    return path.join(ROOT, 'extras', 'ffmpeg-mac', 'ffmpeg')
+  return path.join(ROOT, 'extras', 'ffmpeg-linux', 'ffmpeg')
 }
 
 /* the app shells out to a bundled ffmpeg. CI fetches it before packaging, so

--- a/scripts/run.cjs
+++ b/scripts/run.cjs
@@ -83,6 +83,7 @@ const STEPS = {
   'typecheck:web': [['tsc', '--noEmit', '-p', 'tsconfig.web.json']],
   dist: [['electron-vite', 'build'], ['electron-builder', '--mac']],
   'dist:win': [['electron-vite', 'build'], ['electron-builder', '--win']],
+  'dist:linux': [['electron-vite', 'build'], ['electron-builder', '--linux']],
   'dist:all': [['electron-vite', 'build'], ['electron-builder', '--mac', '--win']]
 }
 
@@ -148,7 +149,7 @@ function runSteps(steps) {
 
 // commands that produce or run the app need the bundled ffmpeg present;
 // typecheck and plain build do not
-const NEEDS_FFMPEG = new Set(['dev', 'dist', 'dist:win', 'dist:all'])
+const NEEDS_FFMPEG = new Set(['dev', 'dist', 'dist:win', 'dist:linux', 'dist:all'])
 
 function main() {
   const cmd = process.argv[2]

--- a/src/main/env.ts
+++ b/src/main/env.ts
@@ -63,26 +63,35 @@ function runtimePython(): string {
     : join(runtimeDir(), 'python', 'bin', 'python3')
 }
 
-function runtimeArchivePath(): string {
+function runtimeTriple(): string {
   const arch = process.arch === 'arm64' ? 'aarch64' : 'x86_64'
-  const triple = IS_WIN ? `${arch}-pc-windows-msvc-shared` : `${arch}-apple-darwin`
-  return join(userDataDir(), `cpython-${PBS_VERSION}-${triple}-install_only.tar.gz`)
+  if (IS_WIN) return `${arch}-pc-windows-msvc-shared`
+  if (process.platform === 'darwin') return `${arch}-apple-darwin`
+  return `${arch}-unknown-linux-gnu`
+}
+
+function runtimeArchivePath(): string {
+  return join(userDataDir(), `cpython-${PBS_VERSION}-${runtimeTriple()}-install_only.tar.gz`)
 }
 
 function runtimeDownloadUrl(): string {
-  const arch = process.arch === 'arm64' ? 'aarch64' : 'x86_64'
-  const triple = IS_WIN ? `${arch}-pc-windows-msvc-shared` : `${arch}-apple-darwin`
   return (
     `https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_TAG}/` +
-    `cpython-${PBS_VERSION}%2B${PBS_TAG}-${triple}-install_only.tar.gz`
+    `cpython-${PBS_VERSION}%2B${PBS_TAG}-${runtimeTriple()}-install_only.tar.gz`
   )
+}
+
+function ffmpegExtraDir(): string {
+  if (IS_WIN) return 'ffmpeg-win'
+  if (process.platform === 'darwin') return 'ffmpeg-mac'
+  return 'ffmpeg-linux'
 }
 
 export function bundledFfmpeg(): string | null {
   const name = 'ffmpeg' + EXE
   const candidates = app.isPackaged
     ? [join(process.resourcesPath, 'ffmpeg', name)]
-    : [join(app.getAppPath(), 'extras', IS_WIN ? 'ffmpeg-win' : 'ffmpeg-mac', name)]
+    : [join(app.getAppPath(), 'extras', ffmpegExtraDir(), name)]
   for (const c of candidates) {
     if (existsSync(c)) return c
   }
@@ -226,7 +235,7 @@ async function detectJsRuntime(): Promise<void> {
         join(homedir(), '.deno', 'bin', 'deno.exe'),
         join(process.env.LOCALAPPDATA ?? '', 'Programs', 'deno', 'deno.exe')
       ]
-    : ['/opt/homebrew/bin/deno', '/usr/local/bin/deno', join(homedir(), '.deno/bin/deno')]
+    : ['/opt/homebrew/bin/deno', '/usr/local/bin/deno', '/usr/bin/deno', join(homedir(), '.deno/bin/deno')]
   for (const p of denoPaths.filter((p): p is string => !!p && p.length > 0)) {
     if (existsSync(p)) {
       state.jsRuntime = { kind: 'deno', path: p }
@@ -252,7 +261,7 @@ async function detectJsRuntime(): Promise<void> {
       }
     } catch {}
   } else {
-    nodeCandidates.push('/opt/homebrew/bin/node', '/usr/local/bin/node')
+    nodeCandidates.push('/opt/homebrew/bin/node', '/usr/local/bin/node', '/usr/bin/node')
     const nvmRoot = join(homedir(), '.nvm/versions/node')
     try {
       for (const ver of readdirSync(nvmRoot)) {
@@ -317,6 +326,9 @@ function pyCandidates(): string[] {
     '/opt/homebrew/bin/python3',
     '/usr/local/bin/python3',
     '/usr/bin/python3',
+    '/usr/bin/python3.12',
+    '/usr/bin/python3.11',
+    '/usr/bin/python3.10',
     join(home, 'opt/anaconda3/bin/python3'),
     join(home, 'anaconda3/bin/python3'),
     join(home, 'miniconda3/bin/python3'),
@@ -362,13 +374,30 @@ interface PyProbe {
   machine: string
 }
 
+/* system pythons on Debian/Ubuntu often lack the venv module
+   (python3-venv not installed), which only surfaces later as a cryptic
+   "ensurepip is not available" failure. Filter them out up front so the
+   private runtime is picked instead */
+async function canCreateVenv(candidate: string): Promise<boolean> {
+  if (candidate === runtimePython()) return true
+  try {
+    await runCapture(candidate, ['-m', 'venv', '--help'], 10000)
+    return true
+  } catch {
+    return false
+  }
+}
+
 export async function detectTools(): Promise<void> {
   const probes: PyProbe[] = []
   const candidates: string[] = []
   if (existsSync(runtimePython())) candidates.push(runtimePython())
   // STEMKIT_FORCE_RUNTIME=1 ignores system python so the private-runtime
-  // download path can be exercised on machines that have python installed
-  if (process.env.STEMKIT_FORCE_RUNTIME !== '1') candidates.push(...pyCandidates())
+  // download path can be exercised on machines that have python installed.
+  // On Linux the private runtime is preferred anyway: system pythons are
+  // commonly missing python3-venv and are PEP 668 externally-managed.
+  const preferRuntime = process.platform === 'linux' || process.env.STEMKIT_FORCE_RUNTIME === '1'
+  if (!preferRuntime) candidates.push(...pyCandidates())
   for (const candidate of candidates) {
     if (!existsSync(candidate)) continue
     try {
@@ -380,10 +409,34 @@ export async function detectTools(): Promise<void> {
       const minor = parseInt(version.split('.')[1], 10)
       const major = parseInt(version.split('.')[0], 10)
       if (major > 3 || (major === 3 && minor >= 10 && minor <= 12)) {
-        probes.push({ path: candidate, version, machine: machine ?? 'unknown' })
+        if (await canCreateVenv(candidate)) {
+          probes.push({ path: candidate, version, machine: machine ?? 'unknown' })
+        }
       }
     } catch {
       continue
+    }
+  }
+  // Linux fallback: no usable python yet (no runtime, system lacks venv
+  // module) — still probe system pythons so the error path can name one.
+  // bootstrap() below will prefer downloading the private runtime.
+  if (probes.length === 0 && preferRuntime) {
+    for (const candidate of pyCandidates()) {
+      if (!existsSync(candidate) || candidates.includes(candidate)) continue
+      try {
+        const out = await runCapture(candidate, [
+          '-c',
+          'import sys,platform;print("%d.%d %s"%(*sys.version_info[:2],platform.machine()))'
+        ])
+        const [version] = out.trim().split(/\s+/)
+        const minor = parseInt(version.split('.')[1], 10)
+        const major = parseInt(version.split('.')[0], 10)
+        if (major > 3 || (major === 3 && minor >= 10 && minor <= 12)) {
+          probes.push({ path: candidate, version, machine: 'no-venv-module' })
+        }
+      } catch {
+        continue
+      }
     }
   }
   probes.sort((a, b) => {
@@ -843,13 +896,55 @@ export async function bootstrap(): Promise<boolean> {
     const pip = venvPython()
 
     sendEnvEvent('Preparing workspace')
-    await new Promise<void>((resolve, reject) => {
-      const child = spawn(state.python.path as string, ['-m', 'venv', '--clear', venv])
-      child.on('close', (code) =>
-        code === 0 ? resolve() : reject(new Error(`venv creation failed (${code})`))
-      )
-      child.on('error', reject)
-    })
+    // On Linux the chosen python may lack the venv module (Debian/Ubuntu
+    // split it into the python3-venv apt package) even though the version
+    // probe passed. Retry once via the private runtime instead of dying.
+    const venvWith = (py: string): Promise<void> =>
+      new Promise<void>((resolve, reject) => {
+        let stderr = ''
+        const child = spawn(py, ['-m', 'venv', '--clear', venv])
+        child.stderr?.on('data', (c: Buffer) => {
+          stderr += c.toString()
+        })
+        child.on('close', (code) =>
+          code === 0
+            ? resolve()
+            : reject(
+                new Error(
+                  `venv creation failed (${code})${stderr ? `: ${stderr.slice(0, 300).trim()}` : ''}`
+                )
+              )
+        )
+        child.on('error', reject)
+      })
+    try {
+      await venvWith(state.python.path as string)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (/ensurepip|venv/i.test(msg) && state.python.path !== runtimePython()) {
+        sendEnvEvent('System python lacks venv support — downloading private runtime instead')
+        state.python = { found: false }
+        if (!(await ensureRuntimePython())) return false
+        await detectTools()
+        if (!state.python.found || !state.python.path) {
+          sendEnvEvent('No suitable python3 found on this machine', 'error')
+          return false
+        }
+        try {
+          await venvWith(state.python.path as string)
+        } catch (err2) {
+          sendEnvEvent(err2 instanceof Error ? err2.message : String(err2), 'error')
+          return false
+        }
+      } else {
+        if (/ensurepip|venv/i.test(msg) && process.platform === 'linux') {
+          sendEnvEvent('venv creation failed: install the venv module (e.g. sudo apt install python3-venv) and retry', 'error')
+        } else {
+          sendEnvEvent(msg, 'error')
+        }
+        return false
+      }
+    }
 
     await new Promise<void>((resolve, reject) => {
       const child = spawn(pip, ['-m', 'pip', 'install', '-q', '-U', 'pip', 'wheel', 'setuptools'])

--- a/src/main/env.ts
+++ b/src/main/env.ts
@@ -36,6 +36,10 @@ const IS_WIN = process.platform === 'win32'
 const EXE = IS_WIN ? '.exe' : ''
 const VENV_BIN = IS_WIN ? 'Scripts' : 'bin'
 
+/* CUDA torch (the GPU engine swap) works on windows and linux; macOS stays
+   on MPS/CPU via the default torch build */
+const SUPPORTS_GPU = IS_WIN || process.platform === 'linux'
+
 export function venvDir(): string {
   return join(userDataDir(), 'venv')
 }
@@ -158,10 +162,10 @@ export function gpuAccelerationInfo(): boolean | undefined {
 let nvidiaProbe: Promise<boolean> | null = null
 let nvidiaInfo: boolean | undefined
 
-/* windows only: whether an NVIDIA GPU is present (nvidia-smi ships with the
-   driver). Gates the GPU-acceleration toggle in Settings */
+/* windows + linux: whether an NVIDIA GPU is present (nvidia-smi ships with
+   the driver). Gates the GPU-acceleration toggle in Settings */
 export function detectNvidiaGpu(): Promise<boolean> {
-  if (!IS_WIN) {
+  if (!SUPPORTS_GPU) {
     nvidiaInfo = false
     return Promise.resolve(false)
   }
@@ -694,10 +698,12 @@ export function ensureFtWeights(onProgress?: (pct: number) => void): Promise<boo
   return ftWeightsPromise.then(detach)
 }
 
-/* CUDA build of torch (windows + nvidia). The default bootstrap installs the
-   CPU wheel from PyPI; this swaps in the cu121 build (~2.5GB download) on
-   demand when the GPU-acceleration toggle is enabled. It stays installed when
-   the toggle goes back off — CUDA torch handles cpu devices fine */
+/* CUDA build of torch (windows/linux + nvidia). The default bootstrap
+   installs the CPU wheel from PyPI (on linux pinned to the cpu index, since
+   the default linux wheel would otherwise pull CUDA deps for everyone);
+   this swaps in the cu121 build (~2.5GB download) on demand when the
+   GPU-acceleration toggle is enabled. It stays installed when the toggle
+   goes back off — CUDA torch handles cpu devices fine */
 const GPU_TORCH_VERSION = '2.5.1'
 const GPU_TORCH_INDEX = 'https://download.pytorch.org/whl/cu121'
 
@@ -713,7 +719,7 @@ export function ensureGpuEngine(
     if (onProgress) gpuProgressListeners.delete(onProgress)
     return true
   }
-  if (!IS_WIN) {
+  if (!SUPPORTS_GPU) {
     detach()
     return Promise.resolve(false)
   }
@@ -829,7 +835,7 @@ export function engineStatus(): EngineStatus {
     ftDownloading: ftWeightsPromise !== null,
     ftVerified,
     gpuDownloading: gpuEnginePromise !== null,
-    gpuReady: IS_WIN && gpuInfo === true
+    gpuReady: SUPPORTS_GPU && gpuInfo === true
   }
 }
 
@@ -956,6 +962,36 @@ export async function bootstrap(): Promise<boolean> {
 
     sendEnvEvent('Downloading the separation engine — grab a coffee')
     let lastGeneric = 0
+    // on linux the default PyPI torch wheel is CUDA-enabled and would pull
+    // ~2GB of nvidia deps for every user, GPU or not — install the cpu build
+    // in its own step (windows/mac defaults are already CPU, so only linux
+    // needs the override) and let the GPU toggle swap in cu121 on demand.
+    // --index-url can't be mixed into the big install below: the cpu index
+    // only hosts torch packages, so non-torch deps would fail to resolve.
+    if (process.platform === 'linux') {
+      await new Promise<void>((resolve, reject) => {
+        const child = spawn(pip, [
+          '-m',
+          'pip',
+          'install',
+          '--progress-bar',
+          'off',
+          'torch==2.5.1',
+          'torchaudio==2.5.1',
+          '--index-url',
+          'https://download.pytorch.org/whl/cpu'
+        ])
+        child.stderr?.on('data', (chunk: Buffer) => {
+          const t = chunk.toString().trim()
+          if (t.startsWith('ERROR') || t.startsWith('error')) sendEnvEvent(t.slice(0, 200), 'error')
+        })
+        child.on('close', (code) =>
+          code === 0 ? resolve() : reject(new Error(`cpu torch install failed (${code})`))
+        )
+        child.on('error', reject)
+      })
+    }
+    // (already satisfied on linux by the cpu step above — pip skips it)
     await new Promise<void>((resolve, reject) => {
       const child = spawn(pip, [
         '-m',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -87,8 +87,10 @@ async function createWindow(): Promise<void> {
     minHeight: 680,
     show: false,
     backgroundColor: '#0b0b10',
-    titleBarStyle: 'hiddenInset',
-    trafficLightPosition: { x: 18, y: 20 },
+    // hiddenInset traffic lights are macOS-only; default frame elsewhere
+    ...(process.platform === 'darwin'
+      ? { titleBarStyle: 'hiddenInset' as const, trafficLightPosition: { x: 18, y: 20 } }
+      : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
       contextIsolation: true,

--- a/src/main/pipeline.ts
+++ b/src/main/pipeline.ts
@@ -124,13 +124,14 @@ export async function startJob(
     (settings.htdemucsFt && engine !== MODEL_EXTENDED ? '-ft' : '') +
     (settings.shifts === 2 ? '@s2' : '')
 
-  // windows honors the GPU toggle: 'cpu' is passed explicitly because
-  // roformer.py's 'auto' prefers CUDA whenever the venv's torch supports it.
-  // macOS keeps 'auto' (MPS when available)
-  const useGpu = settings.gpuSplit && process.platform === 'win32'
+  // windows/linux honor the GPU toggle: 'cpu' is passed explicitly because
+  // roformer.py's 'auto' prefers CUDA whenever the venv's torch supports it
+  // (and the default linux wheel is CUDA-capable, so toggle-off must still
+  // force CPU). macOS keeps 'auto' (MPS when available)
+  const useGpu = settings.gpuSplit && process.platform !== 'darwin'
   const deviceArg = (): string => {
-    if (process.platform === 'win32') return useGpu ? 'cuda' : 'cpu'
-    return 'auto'
+    if (process.platform === 'darwin') return 'auto'
+    return useGpu ? 'cuda' : 'cpu'
   }
 
   const job: ActiveJob = { videoId, model: modelTag, cancelled: false }

--- a/src/main/smoke.ts
+++ b/src/main/smoke.ts
@@ -18,8 +18,11 @@ import {
 } from './env'
 
 /* self-test mode, driven by STEMKIT_SMOKE=1 (used by the windows-smoke CI
-   job): runs the real bootstrap then separates a generated tone through
-   both engines and exits 0/1. No window is created */
+   job and manually on linux): runs the real bootstrap then separates a
+   generated tone through both engines and exits 0/1. No window is created.
+   On machines with an NVIDIA GPU the GPU section runs real cuda separations;
+   on GPU-less runners it checks the fail-fast paths and the CUDA wheel swap
+   with torch.cuda.is_available() staying false */
 
 const LOG_PATH = join(tmpdir(), 'stemkit-smoke.log')
 
@@ -212,11 +215,11 @@ export async function runSmoke(): Promise<boolean> {
     }
     log('roformer vocals ok')
 
-    // GPU plumbing on this GPU-less runner: --device cuda must fail fast
-    // with the friendly message (on the default cpu torch, before any big
-    // downloads), and the CUDA wheel swap must install cleanly while
-    // torch.cuda.is_available() stays false (no NVIDIA driver here). The
-    // real CUDA execution path still needs a machine with an NVIDIA GPU
+    // GPU plumbing: --device cuda must fail fast with the friendly message
+    // on the default cpu torch (before any big downloads). After the CUDA
+    // wheel swap, a GPU-less runner expects torch.cuda.is_available() to
+    // stay false, while an NVIDIA machine runs real cuda separations
+    // through both engines
     const nvidia = await detectNvidiaGpu()
     log(`nvidia gpu detected: ${nvidia}`)
 
@@ -244,25 +247,67 @@ export async function runSmoke(): Promise<boolean> {
           '-c', 'import torch;print("cuda", torch.version.cuda, int(torch.cuda.is_available()))'
         ])
         const [, ver, avail] = info.trim().split(/\s+/)
-        if (!ver || ver === 'None' || avail !== '0') {
-          log(`FAIL: unexpected torch cuda state: "${info.trim()}"`)
+        // driver present: cuda must be usable; otherwise it must stay off
+        const want = nvidia ? '1' : '0'
+        if (!ver || ver === 'None' || avail !== want) {
+          log(`FAIL: unexpected torch cuda state: "${info.trim()}" (want available=${want})`)
           return false
         }
-        log(`cuda torch ok (version.cuda=${ver}, available=0)`)
+        log(`cuda torch ok (version.cuda=${ver}, available=${avail})`)
       } catch (e) {
         log(`FAIL: could not probe torch cuda state: ${e instanceof Error ? e.message : String(e)}`)
         return false
       }
-      if (
-        !(await expectCudaFailure('cuda on cuda torch without nvidia driver', [
+      if (!nvidia) {
+        if (
+          !(await expectCudaFailure('cuda on cuda torch without nvidia driver', [
+            roformerScript(),
+            '--input', mix,
+            '--out', join(dir, 'stems-cuda-roformer'),
+            '--ckpt-dir', modelsDir(),
+            '--device', 'cuda'
+          ]))
+        ) {
+          return false
+        }
+      } else {
+        // real CUDA execution on this machine's GPU, both engines
+        const cudaDemucsOut = join(dir, 'stems-cuda-demucs')
+        const cudaDemucs = await runScript(venvPython(), [
+          separateScript(),
+          '--input', mix,
+          '--out', cudaDemucsOut,
+          '--model', 'htdemucs',
+          '--device', 'cuda'
+        ])
+        if (!cudaDemucs.ok) {
+          log(`FAIL: demucs cuda separation: ${cudaDemucs.error}`)
+          return false
+        }
+        log(`demucs cuda stems: ${cudaDemucs.stems.join(', ')}`)
+        for (const stem of cudaDemucs.stems) {
+          if (!isFloat32Wav(join(cudaDemucsOut, `${stem}.wav`))) {
+            log(`FAIL: cuda ${stem}.wav missing or not float32`)
+            return false
+          }
+        }
+        const cudaRoformerOut = join(dir, 'stems-cuda-roformer')
+        const cudaRoformer = await runScript(venvPython(), [
           roformerScript(),
           '--input', mix,
-          '--out', join(dir, 'stems-cuda-roformer'),
+          '--out', cudaRoformerOut,
           '--ckpt-dir', modelsDir(),
           '--device', 'cuda'
-        ]))
-      ) {
-        return false
+        ])
+        if (!cudaRoformer.ok) {
+          log(`FAIL: roformer cuda separation: ${cudaRoformer.error}`)
+          return false
+        }
+        if (!isFloat32Wav(join(cudaRoformerOut, 'vocals.wav'))) {
+          log('FAIL: cuda vocals.wav missing or not float32')
+          return false
+        }
+        log('cuda separations ok (demucs + roformer)')
       }
     }
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -40,6 +40,11 @@ export function initUpdater(): void {
     }
   })
 
+  // electron-updater only supports AppImage on linux — deb installs update
+  // by re-downloading, so no automatic checks there (the handlers above
+  // stay registered and simply report no update)
+  if (process.platform === 'linux' && !process.env.APPIMAGE) return
+
   setTimeout(() => {
     autoUpdater.checkForUpdatesAndNotify().catch(() => {})
   }, 5000)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -20,7 +20,7 @@ export interface AppSettings {
   shifts: 1 | 2
   htdemucsFt: boolean
   roformerVocals: boolean
-  // windows + nvidia: separate on the GPU instead of the CPU. The toggle is
+  // windows/linux + nvidia: separate on the GPU instead of the CPU. The toggle is
   // only rendered when an NVIDIA GPU is detected; enabling it downloads the
   // CUDA build of torch (~2.5GB) on first use
   gpuSplit: boolean
@@ -45,7 +45,7 @@ export interface EngineStatus {
   vocalsReady: boolean
   ftDownloading: boolean
   ftVerified: boolean
-  // cuda torch engine (windows + nvidia only)
+  // cuda torch engine (windows/linux + nvidia only)
   gpuDownloading: boolean
   gpuReady: boolean
 }
@@ -57,7 +57,7 @@ export interface EnvStatus {
   bootstrapping: boolean
   updating: boolean
   gpu?: boolean
-  // windows only: an NVIDIA GPU was detected (gates the GPU toggle in Settings)
+  // windows/linux only: an NVIDIA GPU was detected (gates the GPU toggle in Settings)
   nvidiaGpu?: boolean
 }
 


### PR DESCRIPTION
Closes #13 

Linux x64 at feature parity with macOS/Windows:
- Dev: `run dev` works: static ffmpeg fetch, Linux python/js-runtime detection, private Python runtime preferred (distro pythons often lack python3-venv), CUDA-aware --device auto.
- GPU: NVIDIA toggle + on-demand CUDA torch swap extended to Linux; CPU torch pinned at bootstrap; explicit cuda/cpu devices.
- Packaging: dist:linux (AppImage + deb, x64 only), ubuntu-22.04 CI job, updater auto-checks AppImage-only.

**Verified**
AppImage built, launched, and splitting on Arch Linux + Wayland + RTX 3060 Ti: 4 stems in ~5s on CUDA vs ~12s for one stem on CPU. macOS/Windows config untouched.

**Out of scope**
arm64 packages and Linux smoke-CI.

**Note**
I left the website out, it still says Windows/macOS only. Happy to fold that into this PR if you want it.